### PR TITLE
Update parsing logic for transaction details to support longer GVC and new separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ are additionally validated for:
 The `transaction.structuredDetails` attribute can be used to access structured
 data from statement transaction details (SWIFT "86" tag).  The following
 structured detail formats are supported:
-- `'<sep>DD'`, where `<sep>` can be `'>'` or `'?'` and `DD` is two digits
+- `'<sep>DD'`, where `<sep>` can be `'>'`, `'<'` or `'?'` and `DD` is two digits
 - `'/TAG/value'`, where `TAG` is 2 to 4 uppercase chars.
 
 **Example**

--- a/lib/field86structure.js
+++ b/lib/field86structure.js
@@ -25,7 +25,7 @@ class Field86StructureParser {
       return;
     } else if (prefix === '/') {                // assume /XXX/ fields
       tagRe = '\\/[0-9A-Z]{2,4}\\/';
-    } else if ('>?'.includes(prefix)) {  // assume >DD fields
+    } else if ('?><'.includes(prefix)) {  // assume >DD fields
       tagRe = `\\${prefix}\\d{2}`;
     } else {
       return; // known separator not found
@@ -47,9 +47,10 @@ class Field86StructureParser {
 
     const parsedStruc = {};
 
-    if (details.match(/^\d\d\d[?>]/)) {
-      parsedStruc.gvc = details.substr(0,3);
-      details = details.substr(3);
+    const gvc = details.match(/^(\d\d\d+)[?><]/);
+    if (gvc) {
+      parsedStruc.gvc = gvc[1];
+      details = details.substr(gvc[1].length);
     }
 
     const rule = Field86StructureParser.buildTagRe(details);


### PR DESCRIPTION
This update modifies the handling of transaction details parsing to accommodate the following use case:

- GVC length with four digits
- Use of < as a separator

Additionally, I wanted to raise the idea of offering more flexibility by allowing users to configure these parameters (GVC length and separator) via environment variables. Happy to provide a PR to handle that.

Please let me know your thoughts on this approach, and if you'd be open to merging this change.

Looking forward to your feedback.

Example of my use case MT940 transaction message:

```
:61:1901310131DN30,00NCHGNONREF//10958
Opłaty okresowe
:86:8090<00Pobranie opłaty<1010958
<20Oplaty i prowizje
<63REF452015339260_19968
```
